### PR TITLE
Added IfOrElseResult with action parameters

### DIFF
--- a/src/D20Tek.Minimal.Result.AspNetCore/D20Tek.Minimal.Result.AspNetCore.csproj
+++ b/src/D20Tek.Minimal.Result.AspNetCore/D20Tek.Minimal.Result.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Title>D20Tek.Minimal.Result.AspNetCore</Title>
     <Company>d20Tek</Company>
     <Description>A straightforward implementation of the Result object pattern. Used to return a monad result that will either be the returned value or a set of errors.

--- a/src/D20Tek.Minimal.Result.Extensions/D20Tek.Minimal.Result.Extensions.csproj
+++ b/src/D20Tek.Minimal.Result.Extensions/D20Tek.Minimal.Result.Extensions.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>D20Tek.Minimal.Result.Extensions</Title>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Company>d20Tek</Company>
     <Description>A straightforward implementation of the Result object pattern. Used to return a monad result that will either be the returned value or a set of errors.
 

--- a/src/D20Tek.Minimal.Result/D20Tek.Minimal.Result.csproj
+++ b/src/D20Tek.Minimal.Result/D20Tek.Minimal.Result.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>D20Tek.Minimal.Result</Title>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Company>d20Tek</Company>
     <Description>A straightforward implementation of the Result object pattern. Used to return a monad result that will either be the returned value or a set of errors.
 	Also added implementation of the Optional object pattern to remove nulls from application code.</Description>

--- a/src/D20Tek.Minimal.Result/ResultAsyncExtensions.cs
+++ b/src/D20Tek.Minimal.Result/ResultAsyncExtensions.cs
@@ -27,7 +27,7 @@ public static class ResultAsyncExtensions
         return task;
     }
 
-    public static Task<Result<TValue>> IfOrElse<TValue>(
+    public static Task<Result<TValue>> IfOrElseResult<TValue>(
         this Result<TValue> result,
         Func<TValue, Task<Result<TValue>>> ifFunc,
         Func<IEnumerable<Error>, Task<Result<TValue>>>? elseFunc = null)

--- a/src/D20Tek.Minimal.Result/ResultT.cs
+++ b/src/D20Tek.Minimal.Result/ResultT.cs
@@ -85,7 +85,24 @@ public class Result<TValue> : Result
         }
     }
 
-    public Result<TValue> IfOrElse(
+    public Result<TValue> IfOrElseResult(Action<TValue> ifAction, Action<IEnumerable<Error>>? elseAction = null)
+    {
+        if (IsSuccess)
+        {
+            ifAction(Value);
+            return this;
+        }
+
+        if (elseAction is not null)
+        {
+            elseAction(Errors);
+            return this;
+        }
+
+        return this;
+    }
+
+    public Result<TValue> IfOrElseResult(
         Func<TValue, Result<TValue>> ifFunc,
         Func<IEnumerable<Error>, Result<TValue>>? elseFunc = null)
     {

--- a/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.IfOrElse.cs
+++ b/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.IfOrElse.cs
@@ -101,7 +101,7 @@ public sealed partial class ResultTTests
         bool successOperationCalled = false, failureOperationCalled = false;
 
         // act
-        var newResult = result.IfOrElse(
+        var newResult = result.IfOrElseResult(
             val => DefaultSuccessActionWithResult(val, ref successOperationCalled),
             [ExcludeFromCodeCoverage] (errors) => DefaultErrorActionWithResult(errors, ref failureOperationCalled));
 
@@ -119,7 +119,7 @@ public sealed partial class ResultTTests
         bool successOperationCalled = false, failureOperationCalled = false;
 
         // act
-        var newResult = result.IfOrElse(
+        var newResult = result.IfOrElseResult(
             [ExcludeFromCodeCoverage] (val) => DefaultSuccessActionWithResult(val, ref successOperationCalled),
             errors => DefaultErrorActionWithResult(errors, ref failureOperationCalled));
 
@@ -137,7 +137,7 @@ public sealed partial class ResultTTests
         bool successOperationCalled = false, failureOperationCalled = false;
 
         // act
-        var newResult = result.IfOrElse(
+        var newResult = result.IfOrElseResult(
             [ExcludeFromCodeCoverage] (val) => DefaultSuccessActionWithResult(val, ref successOperationCalled));
 
         // assert

--- a/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.IfOrElseAsync.cs
+++ b/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.IfOrElseAsync.cs
@@ -84,7 +84,7 @@ public sealed partial class ResultTTests
         Result<TestEntity> result = CreateTestResult();
 
         // act
-        var newResult = await result.IfOrElse<TestEntity>(
+        var newResult = await result.IfOrElseResult<TestEntity>(
             async val => await DefaultSuccessActionWithResultAsync(val),
             [ExcludeFromCodeCoverage] async (errors) => await DefaultErrorActionWithResultAsync(errors));
 
@@ -99,7 +99,7 @@ public sealed partial class ResultTTests
         Result<TestEntity> result = DefaultErrors.Conflict;
 
         // act
-        var newResult = await result.IfOrElse<TestEntity>(
+        var newResult = await result.IfOrElseResult<TestEntity>(
             [ExcludeFromCodeCoverage] async (val) => await DefaultSuccessActionWithResultAsync(val),
             async (errors) => await DefaultErrorActionWithResultAsync(errors));
 
@@ -114,7 +114,7 @@ public sealed partial class ResultTTests
         Result<TestEntity> result = DefaultErrors.Conflict;
 
         // act
-        var newResult = await result.IfOrElse<TestEntity>(
+        var newResult = await result.IfOrElseResult<TestEntity>(
             [ExcludeFromCodeCoverage] async (val) => await DefaultSuccessActionWithResultAsync(val));
 
         // assert

--- a/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.Merge.cs
+++ b/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.Merge.cs
@@ -149,4 +149,66 @@ public sealed partial class ResultTTests
         result.Errors.Count.Should().Be(1);
         result.Errors.First().Code.Should().Be("Test.Failure.Initial");
     }
+
+    [TestMethod]
+    public void IfOrElseResult_WithSuccess_ReturnsSameResult()
+    {
+        // arrange
+        Result<int> initial = 42;
+        bool failureActionCalled = false;
+
+        // act
+        var result = initial.IfOrElseResult(
+            DefaultAction,
+            [ExcludeFromCodeCoverage] (e) => failureActionCalled = true);
+
+        void DefaultAction<T>(T x)
+        {
+            Console.WriteLine($"{0}", x);
+        }
+
+        // assert
+        result.IsSuccess.Should().BeTrue();
+        failureActionCalled.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void IfOrElseResult_WithIsFaliureButNoAction_ReturnsSameResult()
+    {
+        // arrange
+        Result<int> initial = Error.Invalid("Failure", "Test error.");
+
+        // act
+        var result = initial.IfOrElseResult(DefaultAction);
+
+        [ExcludeFromCodeCoverage]
+        void DefaultAction<T>(T x)
+        {
+            Console.WriteLine($"{0}", x);
+        }
+
+        // assert
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void IfOrElseResult_WithFailure_ReturnsSameResult()
+    {
+        // arrange
+        Result<int> initial = Error.Invalid("Failure", "Test error.");
+        bool failureActionCalled = false;
+
+        // act
+        var result = initial.IfOrElseResult(DefaultAction, x => failureActionCalled = true);
+
+        [ExcludeFromCodeCoverage]
+        void DefaultAction<T>(T x)
+        {
+            Console.WriteLine($"{0}", x);
+        }
+
+        // assert
+        result.IsSuccess.Should().BeFalse();
+        failureActionCalled.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
- Added IfOrElseResult with action parameters to handle that use case and return the current result, since the actions return void.
- Renamed IfOrElse overloads to IfOrElseResult for methods that return a new Result<T>. 
- Updated unit tests.
- Updated package version.